### PR TITLE
Catch abi::__forced_unwind and re-throw for unix

### DIFF
--- a/src/sys/snap_threads.cpp
+++ b/src/sys/snap_threads.cpp
@@ -46,7 +46,14 @@ void* ThreadProc(void* param)
         try
         {
             Thread->Execute();
-        } catch (...)
+        }
+#if (defined(POSIX) || defined(OS_OSX))
+        catch (abi::__forced_unwind&)
+        {
+            throw;
+        }
+#endif
+        catch (...)
         {
         };
     Thread->Closed = true;

--- a/src/sys/unix_threads.h
+++ b/src/sys/unix_threads.h
@@ -34,6 +34,7 @@
 #include "snap_sysutils.h"
 #include <semaphore.h>
 #include <pthread.h>
+#include <cxxabi.h>
 //---------------------------------------------------------------------------
 
 class TSnapCriticalSection 


### PR DESCRIPTION
Bug report for Snap7
https://sourceforge.net/p/snap7/tickets/7/

Bug report for python-snap7, which consistently fails without this patch
https://github.com/gijzelaerr/python-snap7/issues/26